### PR TITLE
Inverse mesh transformation

### DIFF
--- a/CSG/Classes/Model.cs
+++ b/CSG/Classes/Model.cs
@@ -32,10 +32,6 @@ namespace Parabox.CSG
             set { m_Indices = value; }
         }
 
-        public Mesh mesh
-        {
-            get { return (Mesh)this; }
-        }
 
         public Model(GameObject gameObject) :
             this(gameObject.GetComponent<MeshFilter>()?.sharedMesh,
@@ -125,15 +121,15 @@ namespace Parabox.CSG
             return list;
         }
 
-        public static explicit operator Mesh(Model model)
+        public Mesh ToMesh(Transform transform)
         {
             var mesh = new Mesh();
-            VertexUtility.SetMesh(mesh, model.m_Vertices);
-            mesh.subMeshCount = model.m_Indices.Count;
+            VertexUtility.SetMesh(mesh, m_Vertices.Select(x => transform.InverseTransformVertex(x)).ToList());
+            mesh.subMeshCount = m_Indices.Count;
             for (int i = 0, c = mesh.subMeshCount; i < c; i++)
             {
 #if UNITY_2019_3_OR_NEWER
-                mesh.SetIndices(model.m_Indices[i], MeshTopology.Triangles, i);
+                mesh.SetIndices(m_Indices[i], MeshTopology.Triangles, i);
 #else
                 mesh.SetIndices(model.m_Indices[i].ToArray(), MeshTopology.Triangles, i);
 #endif

--- a/CSG/Classes/Model.cs
+++ b/CSG/Classes/Model.cs
@@ -32,6 +32,10 @@ namespace Parabox.CSG
             set { m_Indices = value; }
         }
 
+        public Mesh mesh
+        {
+            get { return this.TomMesh(null); }
+        }
 
         public Model(GameObject gameObject) :
             this(gameObject.GetComponent<MeshFilter>()?.sharedMesh,
@@ -124,7 +128,7 @@ namespace Parabox.CSG
         public Mesh ToMesh(Transform transform)
         {
             var mesh = new Mesh();
-            VertexUtility.SetMesh(mesh, m_Vertices.Select(x => transform.InverseTransformVertex(x)).ToList());
+            VertexUtility.SetMesh(mesh, m_Vertices.Select(x => transform == null ? x : transform.InverseTransformVertex(x)).ToList());
             mesh.subMeshCount = m_Indices.Count;
             for (int i = 0, c = mesh.subMeshCount; i < c; i++)
             {

--- a/CSG/Classes/Model.cs
+++ b/CSG/Classes/Model.cs
@@ -31,7 +31,8 @@ namespace Parabox.CSG
             get { return m_Indices; }
             set { m_Indices = value; }
         }
-
+        
+        // [Not recommended] Leaves mesh in world space. Use ToMesh(Transform transform) instead. 
         public Mesh mesh
         {
             get { return this.TomMesh(null); }

--- a/CSG/Classes/VertexUtility.cs
+++ b/CSG/Classes/VertexUtility.cs
@@ -323,5 +323,42 @@ namespace Parabox.CSG
 
             return v;
         }
+		
+	/// <summary>
+	/// Transform a vertex into model space.
+	/// </summary>
+	/// <param name="transform">The transform to apply.</param>
+	/// <param name="vertex">A world space vertex.</param>
+	/// <returns>A new vertex in model coordinate space.</returns>
+	public static Vertex InverseTransformVertex(this Transform transform, Vertex vertex)
+	{
+	    var v = new Vertex();
+	
+	    if (vertex.HasArrays(VertexAttributes.Position))
+	        v.position = transform.InverseTransformPoint(vertex.position);
+	
+	    if (vertex.HasArrays(VertexAttributes.Color))
+	        v.color = vertex.color;
+	
+	    if (vertex.HasArrays(VertexAttributes.Normal))
+	        v.normal = transform.InverseTransformDirection(vertex.normal);
+	
+	    if (vertex.HasArrays(VertexAttributes.Tangent))
+	        v.tangent = Quaternion.Inverse(transform.rotation) * vertex.tangent;
+	
+	    if (vertex.HasArrays(VertexAttributes.Texture0))
+	        v.uv0 = vertex.uv0;
+	
+	    if (vertex.HasArrays(VertexAttributes.Texture1))
+	        v.uv2 = vertex.uv2;
+	
+	    if (vertex.HasArrays(VertexAttributes.Texture2))
+	        v.uv3 = vertex.uv3;
+	
+	    if (vertex.HasArrays(VertexAttributes.Texture3))
+	        v.uv4 = vertex.uv4;
+	
+	    return v;
+	}
 	}
 }


### PR DESCRIPTION
Now returns mesh to model space, if called Model.ToMesh(transform) instead of Model.mesh