### PR TITLE
Fix a typo and an edge case

### DIFF
--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,4 +1,3 @@
-@@ -0,0 +1,7 @@
 fileFormatVersion: 2
 guid: 9e9d365796383ee4ea0baac0dff4fb5c
 TextScriptImporter:

--- a/CSG/Classes/Model.cs
+++ b/CSG/Classes/Model.cs
@@ -1,7 +1,7 @@
 using System;
-using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
 namespace Parabox.CSG
 {

--- a/CSG/Classes/Model.cs
+++ b/CSG/Classes/Model.cs
@@ -35,7 +35,7 @@ namespace Parabox.CSG
         // [Not recommended] Leaves mesh in world space. Use ToMesh(Transform transform) instead. 
         public Mesh mesh
         {
-            get { return this.TomMesh(null); }
+            get { return this.ToMesh(null); }
         }
 
         public Model(GameObject gameObject) :

--- a/CSG/Classes/Node.cs
+++ b/CSG/Classes/Node.cs
@@ -174,7 +174,7 @@ namespace Parabox.CSG
         // Return a list of all polygons in this BSP tree.
         public List<Polygon> AllPolygons()
         {
-            List<Polygon> list = polygons != null ? new List<Polygon>(polygons) : new List<Polygon>();
+            List<Polygon> list = new List<Polygon>(polygons);
             List<Polygon> list_front = new List<Polygon>(), list_back = new List<Polygon>();
 
             // Recursively get all polygons in front subtree

--- a/CSG/Classes/Node.cs
+++ b/CSG/Classes/Node.cs
@@ -174,7 +174,7 @@ namespace Parabox.CSG
         // Return a list of all polygons in this BSP tree.
         public List<Polygon> AllPolygons()
         {
-            List<Polygon> list = new List<Polygon>(polygons);
+            List<Polygon> list = polygons != null ? new List<Polygon>(polygons) : new List<Polygon>();
             List<Polygon> list_front = new List<Polygon>(), list_back = new List<Polygon>();
 
             // Recursively get all polygons in front subtree

--- a/CSG/Classes/Node.cs
+++ b/CSG/Classes/Node.cs
@@ -1,18 +1,17 @@
-using UnityEngine;
+using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace Parabox.CSG
 {
     sealed class Node
     {
-        public List<Polygon> polygons;  // List of polygons in this node
+        public List<Polygon> polygons = new List<Polygon>();  // List of polygons in this node
 
         public Node front;  // Front node (subtree) of the BSP tree
         public Node back;   // Back node (subtree) of the BSP tree
 
-        public Plane plane; // Plane used for partitioning polygons
+        public Plane plane = new Plane(); // Plane used for partitioning polygons
 
         public Node()
         {
@@ -22,11 +21,20 @@ namespace Parabox.CSG
 
         public Node(List<Polygon> list)
         {
+            if (list == null)
+                throw new ArgumentNullException(nameof(list));
+
             Build(list);
         }
 
         public Node(List<Polygon> list, Plane plane, Node front, Node back)
         {
+            if (list == null)
+                throw new ArgumentNullException(nameof(list));
+
+            if (plane == null)
+                throw new ArgumentNullException(nameof(plane));
+
             this.polygons = list;
             this.plane = plane;
             this.front = front;
@@ -86,6 +94,9 @@ namespace Parabox.CSG
         // (no heuristic is used to pick a good split).
         public void Build(List<Polygon> list)
         {
+            if (list == null)
+                throw new ArgumentNullException(nameof(list));
+
             if (list.Count < 1)
                 return;
 

--- a/CSG/Classes/VertexUtility.cs
+++ b/CSG/Classes/VertexUtility.cs
@@ -184,6 +184,12 @@ namespace Parabox.CSG
             if (vertices == null)
                 throw new ArgumentNullException("vertices");
 
+            if (vertices.Count == 0)
+            {
+                mesh.Clear();
+                return;
+            }
+
             Vector3[] positions = null;
             Color[] colors = null;
             Vector2[] uv0s = null;


### PR DESCRIPTION
There are two commits.

1. Commit: Fix typo

    There is a compiler error before fix.

2. Commit: Fix an issue when two identical meshes Subtract

    ```cs
    GameObject cube1 = GameObject.CreatePrimitive(PrimitiveType.Cube);
    GameObject cube2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
    Model result = CSG.Subtract(cube1, cube2);
    ```

    There is an error before fix.

---

P.S. I don't know if the original repository is still maintained or not. This is the fork with newest commits, so I make pull request here. Sorry for bothering :)